### PR TITLE
BUGFIX: Update the duration extraction from the Server-Timing header

### DIFF
--- a/cf_speedtest/speedtest.py
+++ b/cf_speedtest/speedtest.py
@@ -45,7 +45,10 @@ def get_server_timing(server_timing: str) -> float:
     split = server_timing.split(';')
     for part in split:
         if 'dur=' in part:
-            return float(part.split('=')[1]) / 1000
+            try:
+                return float(part.split('=')[1]) / 1000
+            except:
+                return float(part.split(",")[0].split("=")[1]) / 1000
 
 # given an amount of bytes, upload it and return the elapsed seconds taken
 


### PR DESCRIPTION
Recently the Server-Timing header value changed to:
`cfRequestDuration;dur=74.000120, cfL4;desc="?proto=TCP,{rest_of_description_here}"`

Therefore the `split(';')` will result in the following string: `dur=74.000120, cfL4`

When executing the next `float(part.split('=')[1])` it will return `74.000120, cfL4` which cannot be transformed to a float.

This commit will try to extract it that way (in case the headers will change back), and if not - it will extract assuming the new format