### PR TITLE
Print JSON format and allow disabling tests skipping

### DIFF
--- a/cf_speedtest/options.py
+++ b/cf_speedtest/options.py
@@ -69,22 +69,22 @@ def add_run_options(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        '--testpatience',
+        '--testpatience', '-t',
         type=int,
         default=20,
-        help='The longest time to wait for an individual test to run',
+        help='The longest time to wait for an individual test to run. NOTICE: When used with --disableskipping, --testpatience will be ignored',
     )
 
     parser.add_argument(
-        '--disableskipping',
+        '--disableskipping', '-s',
         action='store_true',
-        help='Dont skip any speed test',
+        help='Dont skip any speed test. This will ignore any --testpatience setting ',
     )
 
     parser.add_argument(
-        '--json',
+        '--json', '-j',
         action='store_true',
-        help='Output results of tests in JSON format (When using this option, output will be delayed until the execution is finished)',
+        help='Output results of tests in JSON format. NOTICE: When using this option, output will be delayed until the execution is finished',
     )
 
     return parser

--- a/cf_speedtest/options.py
+++ b/cf_speedtest/options.py
@@ -75,4 +75,16 @@ def add_run_options(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help='The longest time to wait for an individual test to run',
     )
 
+    parser.add_argument(
+        '--disableskipping',
+        action='store_true',
+        help='Dont skip any speed test',
+    )
+
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output results of tests in JSON format (When using this option, output will be delayed until the execution is finished)',
+    )
+
     return parser


### PR DESCRIPTION
In order to get a persistent output that can be used programmaticaly
this commit adds 2 new abilities:
1. Print output in JSON format to be able to parse it
2. Allow disabling the tests skipping. This will allow running all of
   the tests regardless of the patience attribute, which will result in
   a consistent output each time

Here are examples after this change:
```
~ ❯ cf-speedtest
Your IP:	1.2.3.4 (IL)
Server loc:	TLV (TLV) - (IL)

Latency:         9.58 ms
Jitter:          1.79 ms
Running speed tests...

Current speeds:          Down: 111.87 Mbit/sec	Up: 0.00 Mbit/sec
Current speeds:          Down: 111.87 Mbit/sec	Up: 36.36 Mbit/sec
Current speeds:          Down: 513.31 Mbit/sec	Up: 36.36 Mbit/sec
Current speeds:          Down: 513.31 Mbit/sec	Up: 36.36 Mbit/sec
Current speeds:          Down: 463.11 Mbit/sec	Up: 36.36 Mbit/sec
Current speeds:          Down: 463.11 Mbit/sec	Up: 32.00 Mbit/sec
Current speeds:          Down: 463.11 Mbit/sec	Up: 32.00 Mbit/sec
Current speeds:          Down: 456.29 Mbit/sec	Up: 32.00 Mbit/sec
Current speeds:          Down: 456.29 Mbit/sec	Up: 32.00 Mbit/sec
90th percentile results:   Down: 456.29 Mbit/sec	Up: 32.00 Mbit/sec
```

```
~ ❯ cf-speedtest --json
{
    "location": {
        "my_ip_addr": "1.2.3.4",
        "country": "IL",
        "server_city": "TLV",
        "colocation": "TLV",
        "server_country": "IL"
    },
    "latency": "7.66",
    "jitter": "25.28",
    "tests": {
        "100000": {
            "download": "124.06",
            "upload": "32.00"
        },
        "1000000": {
            "download": "124.06",
            "upload": "32.00"
        },
        "10000000": {
            "download": "110.53",
            "upload": "26.23"
        },
        "25000000": {
            "download": "110.53"
        }
    },
    "90_percentile": {
        "download": "110.53",
        "upload": "26.23"
    }
}
```

```
~ ❯ cf-speedtest --disableskipping
Your IP:	1.2.3.4 (IL)
Server loc:	TLV (TLV) - (IL)

Latency:         8.63 ms
Jitter:          7.67 ms
Running speed tests...

Current speeds:          Down: 108.17 Mbit/sec	Up: 0.00 Mbit/sec
Current speeds:          Down: 108.17 Mbit/sec	Up: 26.67 Mbit/sec
Current speeds:          Down: 381.72 Mbit/sec	Up: 26.67 Mbit/sec
Current speeds:          Down: 381.72 Mbit/sec	Up: 26.67 Mbit/sec
Current speeds:          Down: 373.20 Mbit/sec	Up: 26.67 Mbit/sec
Current speeds:          Down: 373.20 Mbit/sec	Up: 25.00 Mbit/sec
Current speeds:          Down: 373.20 Mbit/sec	Up: 25.00 Mbit/sec
Current speeds:          Down: 373.20 Mbit/sec	Up: 25.00 Mbit/sec
Current speeds:          Down: 348.27 Mbit/sec	Up: 25.00 Mbit/sec
Current speeds:          Down: 348.27 Mbit/sec	Up: 24.24 Mbit/sec
Current speeds:          Down: 348.27 Mbit/sec	Up: 24.24 Mbit/sec
Current speeds:          Down: 348.27 Mbit/sec	Up: 24.24 Mbit/sec
90th percentile results:   Down: 348.27 Mbit/sec	Up: 24.24 Mbit/sec
```

```
~ ❯ cf-speedtest --json --disableskipping
{
    "location": {
        "my_ip_addr": "1.2.3.4",
        "country": "IL",
        "server_city": "TLV",
        "colocation": "TLV",
        "server_country": "IL"
    },
    "latency": "9.65",
    "jitter": "5.50",
    "tests": {
        "100000": {
            "download": "105.21",
            "upload": "27.59"
        },
        "1000000": {
            "download": "435.88",
            "upload": "27.59"
        },
        "10000000": {
            "download": "426.05",
            "upload": "22.86"
        },
        "25000000": {
            "download": "426.05",
            "upload": "22.86"
        },
        "100000000": {
            "download": "424.71",
            "upload": "5.81"
        },
        "250000000": {
            "download": "424.71",
            "upload": "5.81"
        }
    },
    "90_percentile": {
        "download": "424.71",
        "upload": "5.81"
    }
}
```